### PR TITLE
Add support for capturing debug information

### DIFF
--- a/home_run/utils.py
+++ b/home_run/utils.py
@@ -25,7 +25,7 @@ def compute_wrapper(capture_output: bool = True) -> Dict[str, Any]:
     # Code graciously adapted from QCEngine:
     #  https://github.com/MolSSI/QCEngine/blob/4a92ee6a0dcea42316e00f9f9a7c07d95cbda111/qcengine/util.py#L97
 
-    metadata = {"stdout": None, "stderr": None, "success": True}
+    metadata = {"stdout": None, "stderr": None, "success": True, "exc": None, "error_message": None, "wall_time": None}
 
     # Start timer
     comp_time = monotonic()

--- a/home_run/utils.py
+++ b/home_run/utils.py
@@ -25,7 +25,8 @@ def compute_wrapper(capture_output: bool = True) -> Dict[str, Any]:
     # Code graciously adapted from QCEngine:
     #  https://github.com/MolSSI/QCEngine/blob/4a92ee6a0dcea42316e00f9f9a7c07d95cbda111/qcengine/util.py#L97
 
-    metadata = {"stdout": None, "stderr": None, "success": True, "exc": None, "error_message": None, "wall_time": None}
+    metadata = {"stdout": None, "stderr": None, "success": True, 
+                "exc": None, "error_message": None, "wall_time": None}
 
     # Start timer
     comp_time = monotonic()

--- a/home_run/utils.py
+++ b/home_run/utils.py
@@ -1,0 +1,55 @@
+"""Utility operations related to building and executing home_run shims"""
+import traceback
+from contextlib import contextmanager
+from typing import Dict, Any
+from time import monotonic
+from io import StringIO
+import sys
+
+
+@contextmanager
+def compute_wrapper(capture_output: bool = True) -> Dict[str, Any]:
+    """Wraps compute for timing, output capturing, and raise protection
+
+    Args:
+        capture_output: Whether to store the stdout and stderr rather than print to screen
+    Yields:
+        Metadata about the execution:
+            - success: Whether the code inside ran without raising an exception
+            - stdout/stderr: Captured standard output and error, if requested
+            - timing: Execution time for the segment in seconds
+            - exc: Captured exception object
+            - error_message: Exception traceback
+    """
+
+    # Code graciously adapted from QCEngine:
+    #  https://github.com/MolSSI/QCEngine/blob/4a92ee6a0dcea42316e00f9f9a7c07d95cbda111/qcengine/util.py#L97
+
+    metadata = {"stdout": None, "stderr": None, "success": True}
+
+    # Start timer
+    comp_time = monotonic()
+
+    # Capture stdout/err
+    new_stdout = StringIO()
+    new_stderr = StringIO()
+    if capture_output:
+        old_stdout, sys.stdout = sys.stdout, new_stdout
+        old_stderr, sys.stderr = sys.stderr, new_stderr
+    try:
+        yield metadata
+
+    # Unknown QCEngine exception likely in the Python layer, show traceback
+    except Exception as exc:
+        metadata["exc"] = exc
+        metadata["error_message"] = traceback.format_exc()
+        metadata["success"] = False
+
+    # Place data
+    metadata["wall_time"] = monotonic() - comp_time
+    if capture_output:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        # Pull over values
+        metadata["stdout"] = new_stdout.getvalue() or None
+        metadata["stderr"] = new_stderr.getvalue() or None

--- a/home_run/utils.py
+++ b/home_run/utils.py
@@ -25,7 +25,7 @@ def compute_wrapper(capture_output: bool = True) -> Dict[str, Any]:
     # Code graciously adapted from QCEngine:
     #  https://github.com/MolSSI/QCEngine/blob/4a92ee6a0dcea42316e00f9f9a7c07d95cbda111/qcengine/util.py#L97
 
-    metadata = {"stdout": None, "stderr": None, "success": True, 
+    metadata = {"stdout": None, "stderr": None, "success": True,
                 "exc": None, "error_message": None, "wall_time": None}
 
     # Start timer

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -1,0 +1,56 @@
+"""Tests related to the debug wrapper"""
+from dlhub_sdk.models.servables.python import PythonStaticMethodModel
+from pytest import fixture, raises
+
+from home_run.python import PythonStaticMethodServable
+
+
+def run(success: bool):
+    print('Hello, pytest.')
+    if success:
+        return True
+    else:
+        raise ValueError('No!')
+
+
+@fixture
+def shim():
+    model = PythonStaticMethodModel.from_function_pointer(run)
+    model.set_name('test')
+    model.set_title('Test')
+    model.set_inputs('bool', 'Whether to run successfully')
+    model.set_outputs('bool', 'Should always be True')
+    return PythonStaticMethodServable(**model.to_dict())
+
+
+def test_normal_execution(shim, capsys):
+    result, metadata = shim.run(True)
+    assert result
+    assert metadata['success']
+    assert metadata['stdout'] is None
+    assert metadata['stderr'] is None
+    assert 'wall_time' in metadata
+
+    # Check to make sure some printing happened
+    captured = capsys.readouterr()
+    assert captured.out.startswith('Hello, pytest')
+
+
+def test_debugging(shim):
+    result, metadata = shim.run(True, debug=True)
+    assert metadata['success']
+    assert metadata['stdout'].startswith('Hello, pytest')
+    assert metadata['stderr'] is None
+    assert 'wall_time' in metadata
+
+
+def test_error(shim):
+    result, metadata = shim.run(False, debug=True)
+    assert result is None
+    assert not metadata['success']
+    assert metadata['stdout'].startswith('Hello, pytest')
+    assert 'No!' in metadata['error_message']
+
+    with raises(ValueError) as exc:
+        raise metadata['exc']
+    assert str(exc.value) == 'No!'

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -82,7 +82,7 @@ def test_keras_multioutput(tmpdir):
     servable = KerasServable(**metadata.to_dict())
     x = [[1]]
     servable.run(x)
-    assert np.isclose(model.predict(np.array(x)), servable.run(x)).all()
+    assert np.isclose(model.predict(np.array(x)), servable.run(x)[0]).all()
 
 
 def test_keras_multifile(tmpdir):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -18,4 +18,4 @@ class TestLoader(TestCase):
         # Test the loader
         servable = create_servable(model.to_dict())
         self.assertIsInstance(servable, PythonStaticMethodServable)
-        self.assertEqual([0], servable.run([0, -1]))
+        self.assertEqual([0], servable.run([0, -1])[0])

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,8 +2,6 @@ from dlhub_sdk.models.servables.python import PythonStaticMethodModel, PythonCla
 from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
 from dlhub_sdk.utils.types import compose_argument_block
 from home_run.version import __version__
-from unittest import TestCase
-from tempfile import mkstemp
 from platform import system
 import pickle as pkl
 import numpy as np
@@ -27,190 +25,189 @@ class ExampleClass:
         return self.a * x + b
 
 
-class TestPython(TestCase):
+def test_static():
+    # Make an example static method
+    model = PythonStaticMethodModel.create_model('numpy', 'max', autobatch=False,
+                                                 function_kwargs={'axis': 0})
+    model.set_title('Example function')
+    model.set_name('function')
+    model.set_inputs('ndarray', 'Matrix', shape=[None, None])
+    model.set_outputs('ndarray', 'Max of a certain axis', shape=[None])
 
-    def test_static(self):
-        # Make an example static method
-        model = PythonStaticMethodModel.create_model('numpy', 'max', autobatch=False,
-                                                     function_kwargs={'axis': 0})
-        model.set_title('Example function')
-        model.set_name('function')
-        model.set_inputs('ndarray', 'Matrix', shape=[None, None])
-        model.set_outputs('ndarray', 'Max of a certain axis', shape=[None])
+    # Make the servable
+    servable = PythonStaticMethodServable(**model.to_dict())
 
-        # Make the servable
-        servable = PythonStaticMethodServable(**model.to_dict())
+    # Test it
+    out, _ = servable.run([[1, 2], [3, 4]])
+    assert np.isclose([3, 4], out).all()
 
-        # Test it
-        self.assertTrue(np.isclose([3, 4], servable.run([[1, 2], [3, 4]])).all())
+    # Test giving it parameters
+    assert np.isclose([2, 4], servable.run([[1, 2], [3, 4]], parameters=dict(axis=1))[0]).all()
 
-        # Test giving it parameters
-        self.assertTrue(np.isclose([2, 4], servable.run([[1, 2], [3, 4]],
-                                                        parameters=dict(axis=1))).all())
+    # Test the autobatch
+    model.servable.methods['run'].method_details['autobatch'] = True
+    servable = PythonStaticMethodServable(**model.to_dict())
 
-        # Test the autobatch
-        model.servable.methods['run'].method_details['autobatch'] = True
-        servable = PythonStaticMethodServable(**model.to_dict())
+    out, _ = servable.run([[1, 2], [3, 4]])
+    assert np.isclose([2, 4], out).all()
 
-        self.assertTrue(np.isclose([2, 4], servable.run([[1, 2], [3, 4]])).all())
 
-    def test_pickle(self):
-        # Make an example class
-        x = ExampleClass(2)
+def test_pickle(tmpdir):
+    # Make an example class
+    x = ExampleClass(2)
 
-        # Save a pickle
-        fp, filename = mkstemp('.pkl')
-        os.close(fp)
-        try:
-            with open(filename, 'wb') as fp:
-                pkl.dump(x, fp)
+    # Save a pickle
+    out_file = tmpdir / 'test.pkl'
+    with open(out_file, 'wb') as fp:
+        pkl.dump(x, fp)
 
-            # Make the metadata file
-            model = PythonClassMethodModel.create_model(filename, 'f')
-            model.set_title('Example function')
-            model.set_name('function')
-            model.set_inputs('float', 'Input')
-            model.set_outputs('float', 'Output')
+    # Make the metadata file
+    model = PythonClassMethodModel.create_model(out_file, 'f')
+    model.set_title('Example function')
+    model.set_name('function')
+    model.set_inputs('float', 'Input')
+    model.set_outputs('float', 'Output')
 
-            # Make the servable
-            servable = PythonClassMethodServable(**model.to_dict())
+    # Make the servable
+    servable = PythonClassMethodServable(**model.to_dict())
 
-            # Test the servable
-            self.assertAlmostEqual(3, servable.run(1))
-            self.assertAlmostEqual(4, servable.run(1, parameters=dict(b=2)))
+    # Test the servable
+    assert servable.run(1)[0] == 3
+    assert servable.run(1, parameters=dict(b=2))[0] == 4
 
-            # Test operations for the base class
-            self.assertEqual(__version__, servable.get_version())
-            self.assertEqual(model.to_dict(), servable.get_recipe())
+    # Test operations for the base class
+    assert __version__ == servable.get_version()
+    assert model.to_dict() == servable.get_recipe()
 
-        finally:
-            os.unlink(filename)
 
-    def test_multiargs(self):
-        # Make the maximum function
-        model = PythonStaticMethodModel.from_function_pointer(max)\
-            .set_name('test').set_title('test')
+def test_multiargs():
+    # Make the maximum function
+    model = PythonStaticMethodModel.from_function_pointer(max) \
+        .set_name('test').set_title('test')
 
-        # Describe the inputs
-        model.set_inputs('tuple', 'Two numbers',
+    # Describe the inputs
+    model.set_inputs('tuple', 'Two numbers',
+                     element_types=[
+                         compose_argument_block('float', 'A number'),
+                         compose_argument_block('float', 'A second number')
+                     ])
+    model.set_outputs('float', 'Maximum of the two numbers')
+    model.set_unpack_inputs(True)
+
+    # Make sure the shim works
+    servable = PythonStaticMethodServable(**model.to_dict())
+    assert servable.run((1, 2))[0] == 2
+
+
+def test_multiargs_autobatch():
+    # Make the maximum function
+    model = PythonStaticMethodModel.from_function_pointer(max, autobatch=True) \
+        .set_name('test').set_title('test')
+
+    # Describe the inputs
+    model.set_inputs('list', 'List of pairs of numbers',
+                     item_type=compose_argument_block(
+                         'tuple', 'Two numbers',
                          element_types=[
                              compose_argument_block('float', 'A number'),
                              compose_argument_block('float', 'A second number')
-                         ])
-        model.set_outputs('float', 'Maximum of the two numbers')
-        model.set_unpack_inputs(True)
+                         ]))
+    model.set_outputs('list', 'Maximum of each pair', item_type='float')
+    model.set_unpack_inputs(True)
 
-        # Make sure the shim works
-        servable = PythonStaticMethodServable(**model.to_dict())
-        self.assertEquals(servable.run((1, 2)), 2)
+    # Make sure the shim works
+    servable = PythonStaticMethodServable(**model.to_dict())
+    out, _ = servable.run([(1, 2)])
+    assert out == [2]
 
-    def test_multiargs_autobatch(self):
-        # Make the maximum function
-        model = PythonStaticMethodModel.from_function_pointer(max, autobatch=True)\
-            .set_name('test').set_title('test')
 
-        # Describe the inputs
-        model.set_inputs('list', 'List of pairs of numbers',
-                         item_type=compose_argument_block(
-                             'tuple', 'Two numbers',
-                             element_types=[
-                                 compose_argument_block('float', 'A number'),
-                                 compose_argument_block('float', 'A second number')
-                             ]))
-        model.set_outputs('list', 'Maximum of each pair', item_type='float')
-        model.set_unpack_inputs(True)
+def test_multiargs_pickle(tmpdir):
+    # Make an example class
+    x = ExampleClass(2)
 
-        # Make sure the shim works
-        servable = PythonStaticMethodServable(**model.to_dict())
-        self.assertEquals(servable.run([(1, 2)]), [2])
+    # Save a pickle
+    filename = str(tmpdir / 'test.pkl')
+    with open(filename, 'wb') as fp:
+        pkl.dump(x, fp)
 
-    def test_multiargs_pickle(self):
-        # Make an example class
-        x = ExampleClass(2)
+    # Make the metadata file
+    model = PythonClassMethodModel.create_model(filename, 'f')
+    model.set_title('Example function')
+    model.set_name('function')
+    model.set_inputs('tuple', 'inputs',
+                     element_types=[compose_argument_block('float', 'Number')] * 2)
+    model.set_outputs('float', 'Output')
+    model.set_unpack_inputs(True)
 
-        # Save a pickle
-        fp, filename = mkstemp('.pkl')
-        os.close(fp)
-        try:
-            with open(filename, 'wb') as fp:
-                pkl.dump(x, fp)
+    # Make the servable
+    validate_against_dlhub_schema(model.to_dict(), 'servable')
+    servable = PythonClassMethodServable(**model.to_dict())
 
-            # Make the metadata file
-            model = PythonClassMethodModel.create_model(filename, 'f')
-            model.set_title('Example function')
-            model.set_name('function')
-            model.set_inputs('tuple', 'inputs',
-                             element_types=[compose_argument_block('float', 'Number')]*2)
-            model.set_outputs('float', 'Output')
-            model.set_unpack_inputs(True)
+    # Test the servable
+    assert 4 == servable.run([1, 2])[0]
 
-            # Make the servable
-            validate_against_dlhub_schema(model.to_dict(), 'servable')
-            servable = PythonClassMethodServable(**model.to_dict())
 
-            # Test the servable
-            self.assertAlmostEqual(4, servable.run([1, 2]))
+def test_single_file_input(tmpdir):
+    # Make the metadata model
+    model = PythonStaticMethodModel.from_function_pointer(os.path.isfile).set_name('test')
+    model.set_title('test')
+    model.set_inputs('file', 'A file')
+    model.set_outputs('boolean', 'Whether it exists')
 
-        finally:
-            os.unlink(filename)
+    # Make the servable
+    servable = PythonStaticMethodServable(**model.to_dict())
 
-    def test_single_file_input(self):
-        # Make the metadata model
-        model = PythonStaticMethodModel.from_function_pointer(os.path.isfile).set_name('test')
-        model.set_title('test')
-        model.set_inputs('file', 'A file')
-        model.set_outputs('boolean', 'Whether it exists')
+    # Run on local file
+    assert servable.run({'url': __file__})[0]
+    if system() != 'Windows':
+        assert servable.run({'url': 'file:///' + __file__})[0]
 
-        # Make the servable
-        servable = PythonStaticMethodServable(**model.to_dict())
+    # Run on remote file
+    assert servable.run({
+        'url': 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png'}
+    )[0]
 
-        # Run on local file
-        self.assertTrue(servable.run({'url': __file__}))
-        if system() != 'Windows':
-            self.assertTrue(servable.run({'url': 'file:///' + __file__}))  # Fail on Windows
 
-        # Run on remote file
-        self.assertTrue(servable.run({'url': 'https://www.google.com/images/branding/'
-                                             'googlelogo/1x/googlelogo_color_272x92dp.png'}))
+def test_single_file_list_input():
+    # Make the metadata model
+    model = PythonStaticMethodModel.from_function_pointer(os.path.isfile, autobatch=True)
+    model.set_name('test')
+    model.set_title('test')
+    model.set_inputs('list', 'List of files', item_type='file')
+    model.set_outputs('list', 'Whether each file exists', item_type='boolean')
 
-    def test_single_file_list_input(self):
-        # Make the metadata model
-        model = PythonStaticMethodModel.from_function_pointer(os.path.isfile, autobatch=True)
-        model.set_name('test')
-        model.set_title('test')
-        model.set_inputs('list', 'List of files', item_type='file')
-        model.set_outputs('list', 'Whether each file exists', item_type='boolean')
+    # Make the servable
+    servable = PythonStaticMethodServable(**model.to_dict())
 
-        # Make the servable
-        servable = PythonStaticMethodServable(**model.to_dict())
+    # Run on local file
+    assert servable.run([{'url': __file__}])[0]
+    if system() != 'Windows':
+        assert servable.run([{'url': 'file:///' + __file__}])[0]  # Fail on Windows
 
-        # Run on local file
-        self.assertTrue(servable.run([{'url': __file__}]))
-        if system() != 'Windows':
-            self.assertTrue(servable.run([{'url': 'file:///' + __file__}]))  # Fail on Windows
+    # Run on remote file
+    assert servable.run([{
+        'url': 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png'
+    }])[0]
 
-        # Run on remote file
-        self.assertTrue(servable.run([{'url': 'https://www.google.com/images/branding/'
-                                              'googlelogo/1x/googlelogo_color_272x92dp.png'}]))
 
-    def test_file_multiinput(self):
-        model = PythonStaticMethodModel.from_function_pointer(multifile_input)
-        model.set_name('test')
-        model.set_title('test')
-        model.set_inputs('tuple', 'Several things', element_types=[
-            compose_argument_block('file', 'Single file'),
-            compose_argument_block('list', 'Multiple files', item_type='file'),
-            compose_argument_block('boolean', 'Something random')
-        ])
-        model.set_outputs('bool', 'Should be True')
-        model.set_unpack_inputs(True)
+def test_file_multiinput():
+    model = PythonStaticMethodModel.from_function_pointer(multifile_input)
+    model.set_name('test')
+    model.set_title('test')
+    model.set_inputs('tuple', 'Several things', element_types=[
+        compose_argument_block('file', 'Single file'),
+        compose_argument_block('list', 'Multiple files', item_type='file'),
+        compose_argument_block('boolean', 'Something random')
+    ])
+    model.set_outputs('bool', 'Should be True')
+    model.set_unpack_inputs(True)
 
-        # Make the servable
-        servable = PythonStaticMethodServable(**model.to_dict())
+    # Make the servable
+    servable = PythonStaticMethodServable(**model.to_dict())
 
-        # Test it
-        self.assertTrue(servable.run([
-            {'url': __file__},
-            [{'url': __file__}],
-            True
-        ]))
+    # Test it
+    assert servable.run([
+        {'url': __file__},
+        [{'url': __file__}],
+        True
+    ])[0]


### PR DESCRIPTION
Fixes #13

Does a lot:

- Adds a "capture_output" context manager
- Uses it inside of a the "new_function" closure
- Returns the metadata captured by the capture_output context manager
- Updates all of the tests accordingly

Is going to break the DLHub client if not handled properly